### PR TITLE
Add dataset loader utility and tests

### DIFF
--- a/inventory/__init__.py
+++ b/inventory/__init__.py
@@ -10,6 +10,7 @@ from .abc_analysis import classify_inventory
 from .eoq import calculate_eoq
 from .reorder_point import calculate_reorder_point
 from .lead_time import compute_lead_times
+from .datasets import load_datasets
 
 __all__ = [
     "forecast_demand",
@@ -17,4 +18,5 @@ __all__ = [
     "calculate_eoq",
     "calculate_reorder_point",
     "compute_lead_times",
+    "load_datasets",
 ]

--- a/inventory/datasets.py
+++ b/inventory/datasets.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Utilities for working with the bundled ZIP datasets.
+
+This module exposes :func:`load_datasets` which reads all CSV files from a
+zip archive into :class:`pandas.DataFrame` objects.  The function is
+lightweight and does not make assumptions about the structure of the CSV
+files, making it suitable for loading the sample datasets included with the
+project as well as synthetic datasets used in tests.
+"""
+
+from pathlib import Path
+import zipfile
+from typing import Iterable, Mapping
+
+import pandas as pd
+
+
+def load_datasets(
+    zip_path: str | Path,
+    *,
+    files: Iterable[str] | None = None,
+) -> Mapping[str, pd.DataFrame]:
+    """Load CSV files from ``zip_path``.
+
+    Parameters
+    ----------
+    zip_path:
+        Path to a zip archive containing one or more CSV files.
+    files:
+        Optional iterable of file names to load from the archive.  If ``None``
+        all CSV files are loaded.  Names are matched against the base name of
+        each file inside the archive (e.g. ``"sales.csv"``).
+
+    Returns
+    -------
+    dict[str, pandas.DataFrame]
+        Mapping of file stem (e.g. ``"sales"``) to its corresponding
+        :class:`~pandas.DataFrame`.
+    """
+    path = Path(zip_path)
+    if not path.is_file():  # pragma: no cover - sanity check
+        raise FileNotFoundError(f"{zip_path!r} does not exist")
+
+    with zipfile.ZipFile(path) as zf:
+        members = [name for name in zf.namelist() if name.lower().endswith('.csv')]
+        if files is not None:
+            wanted = {Path(f).name for f in files}
+            members = [m for m in members if Path(m).name in wanted]
+
+        data: dict[str, pd.DataFrame] = {}
+        for member in members:
+            with zf.open(member) as fp:
+                df = pd.read_csv(fp)
+            data[Path(member).stem] = df
+
+    return data

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import zipfile
+
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from inventory import load_datasets, classify_inventory
+
+
+def _make_zip(path, files):
+    """Helper to create a zip file at *path* from a mapping of name->DataFrame."""
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, df in files.items():
+            zf.writestr(f"{name}.csv", df.to_csv(index=False))
+    return path
+
+
+def test_load_datasets(tmp_path):
+    df1 = pd.DataFrame({"a": [1, 2]})
+    df2 = pd.DataFrame({"b": ["x", "y"]})
+    zip_path = _make_zip(tmp_path / "data.zip", {"first": df1, "second": df2})
+
+    loaded = load_datasets(zip_path)
+    assert loaded["first"].equals(df1)
+    assert loaded["second"].equals(df2)
+
+
+def test_classify_with_loaded_data(tmp_path):
+    inv_df = pd.DataFrame({"item": list("ABC"), "value": [100, 50, 10]})
+    zip_path = _make_zip(tmp_path / "inv.zip", {"inventory": inv_df})
+
+    datasets = load_datasets(zip_path)
+    classified = classify_inventory(datasets["inventory"], "value")
+    categories = classified.set_index("item")["category"].to_dict()
+    assert categories == {"A": "A", "B": "B", "C": "C"}


### PR DESCRIPTION
## Summary
- add helper to load CSV files from dataset ZIP archives
- expose loader via inventory package
- test dataset loader and integration with ABC analysis

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac67d85a6c832a967432b8027d02b4