### PR TITLE
Add sales analysis utilities for top selling products

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,24 @@
 
 ## Datasets
 Datasets can be downloaded from this link [DataSet](https://www.kaggle.com/datasets/sloozecareers/slooze-challenge/data)
+
+## 🧪 Example: Sales Insights
+
+The :mod:`inventory` package provides helpers for analysing the provided
+``datasets.zip`` archive.  For instance, the snippet below prints the five
+best-selling products from the sales dataset:
+
+```python
+from inventory import top_selling_from_zip
+
+top = top_selling_from_zip(
+    "datasets.zip",
+    sales_file="SalesFINAL12312016.csv",  # name inside the archive
+    product_col="Item",                   # product identifier column
+    quantity_col="Quantity",              # quantity sold column
+    top_n=5,
+)
+print(top)
+```
+
+Adjust the column names according to those used in the dataset.

--- a/inventory/__init__.py
+++ b/inventory/__init__.py
@@ -11,6 +11,7 @@ from .eoq import calculate_eoq
 from .reorder_point import calculate_reorder_point
 from .lead_time import compute_lead_times
 from .datasets import load_datasets
+from .sales_analysis import top_selling_from_zip, top_selling_products
 
 __all__ = [
     "forecast_demand",
@@ -19,4 +20,6 @@ __all__ = [
     "calculate_reorder_point",
     "compute_lead_times",
     "load_datasets",
+    "top_selling_products",
+    "top_selling_from_zip",
 ]

--- a/inventory/sales_analysis.py
+++ b/inventory/sales_analysis.py
@@ -1,0 +1,75 @@
+"""Sales analysis utilities."""
+from __future__ import annotations
+
+from pathlib import Path
+import pandas as pd
+
+from .datasets import load_datasets
+
+
+def top_selling_products(
+    df: pd.DataFrame,
+    product_col: str,
+    quantity_col: str,
+    *,
+    top_n: int = 10,
+) -> pd.DataFrame:
+    """Return the top ``top_n`` products by quantity sold.
+
+    Parameters
+    ----------
+    df:
+        Sales data containing product and quantity columns.
+    product_col:
+        Column identifying the product.
+    quantity_col:
+        Column representing quantity sold.
+    top_n:
+        Number of top products to return.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame with ``product_col`` and ``total_quantity`` columns
+        sorted in descending order of quantity.
+    """
+    for col in (product_col, quantity_col):
+        if col not in df.columns:
+            raise KeyError(f"{col!r} not in DataFrame")
+    if top_n <= 0:
+        raise ValueError("top_n must be positive")
+
+    aggregated = (
+        df.groupby(product_col)[quantity_col]
+        .sum()
+        .sort_values(ascending=False)
+        .head(top_n)
+        .rename("total_quantity")
+        .reset_index()
+    )
+    return aggregated
+
+
+def top_selling_from_zip(
+    zip_path: str | Path,
+    *,
+    sales_file: str,
+    product_col: str,
+    quantity_col: str,
+    top_n: int = 10,
+) -> pd.DataFrame:
+    """Load sales data from ``zip_path`` and compute top products.
+
+    This is a convenience wrapper around :func:`load_datasets` and
+    :func:`top_selling_products`.
+    """
+    datasets = load_datasets(zip_path, files=[sales_file])
+    key = Path(sales_file).stem
+    if key not in datasets:
+        raise FileNotFoundError(f"{sales_file!r} not found in {zip_path!r}")
+    return top_selling_products(
+        datasets[key],
+        product_col,
+        quantity_col,
+        top_n=top_n,
+    )

--- a/tests/test_sales_analysis.py
+++ b/tests/test_sales_analysis.py
@@ -1,0 +1,37 @@
+import os
+import sys
+import zipfile
+
+import pandas as pd
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from inventory import top_selling_products, top_selling_from_zip
+
+
+def _make_zip(path, files):
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, df in files.items():
+            zf.writestr(f"{name}.csv", df.to_csv(index=False))
+    return path
+
+
+def test_top_selling_products():
+    df = pd.DataFrame({"product": ["A", "B", "A", "C"], "qty": [10, 5, 3, 20]})
+    result = top_selling_products(df, "product", "qty", top_n=2)
+    assert list(result["product"]) == ["C", "A"]
+    assert list(result["total_quantity"]) == [20, 13]
+
+
+def test_top_selling_from_zip(tmp_path):
+    df = pd.DataFrame({"product": ["A", "B", "A"], "qty": [10, 5, 3]})
+    zip_path = _make_zip(tmp_path / "sales.zip", {"sales": df})
+    result = top_selling_from_zip(
+        zip_path,
+        sales_file="sales.csv",
+        product_col="product",
+        quantity_col="qty",
+        top_n=1,
+    )
+    assert result.iloc[0]["product"] == "A"
+    assert result.iloc[0]["total_quantity"] == 13


### PR DESCRIPTION
## Summary
- add `top_selling_products` and `top_selling_from_zip` to compute top products from sales data
- document usage example in README and export helpers in package
- include tests for sales analysis

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac6bf8a44c832a8e5d697261fdc01f