### PR TITLE
Add zip-based dataset helpers and sample archive utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,19 @@ print(top)
 ```
 
 Adjust the column names according to those used in the dataset.
+
+### Working with the bundled sample data
+
+For a quick start the repository includes a smaller ``Sample.zip`` archive.
+Most functions now provide ``*_from_zip`` helpers that load the relevant CSV
+directly from the archive.  For example, to list the top products in the sample
+sales dataset:
+
+```python
+from inventory import top_selling_sample
+
+print(top_selling_sample())  # defaults to "Sample.zip" in the project root
+```
+
+Similar helpers exist for demand forecasting, lead time analysis and other
+inventory calculations.

--- a/inventory/__init__.py
+++ b/inventory/__init__.py
@@ -5,21 +5,38 @@ forecasting, ABC classification, EOQ, reorder point and lead time
 calculations.
 """
 
-from .demand_forecasting import forecast_demand
-from .abc_analysis import classify_inventory
-from .eoq import calculate_eoq
-from .reorder_point import calculate_reorder_point
-from .lead_time import compute_lead_times
-from .datasets import load_datasets
-from .sales_analysis import top_selling_from_zip, top_selling_products
+from .demand_forecasting import forecast_demand, forecast_from_zip
+from .abc_analysis import classify_inventory, classify_inventory_from_zip
+from .eoq import calculate_eoq, calculate_eoq_from_df, calculate_eoq_from_zip
+from .reorder_point import (
+    calculate_reorder_point,
+    calculate_reorder_points_from_df,
+    calculate_reorder_points_from_zip,
+)
+from .lead_time import compute_lead_times, compute_lead_times_from_zip
+from .datasets import load_datasets, load_sample_datasets
+from .sales_analysis import (
+    top_selling_from_zip,
+    top_selling_products,
+    top_selling_sample,
+)
 
 __all__ = [
     "forecast_demand",
+    "forecast_from_zip",
     "classify_inventory",
+    "classify_inventory_from_zip",
     "calculate_eoq",
+    "calculate_eoq_from_df",
+    "calculate_eoq_from_zip",
     "calculate_reorder_point",
+    "calculate_reorder_points_from_df",
+    "calculate_reorder_points_from_zip",
     "compute_lead_times",
+    "compute_lead_times_from_zip",
     "load_datasets",
+    "load_sample_datasets",
     "top_selling_products",
     "top_selling_from_zip",
+    "top_selling_sample",
 ]

--- a/inventory/datasets.py
+++ b/inventory/datasets.py
@@ -55,3 +55,25 @@ def load_datasets(
             data[Path(member).stem] = df
 
     return data
+
+
+def load_sample_datasets(zip_path: str | Path) -> Mapping[str, pd.DataFrame]:
+    """Convenience wrapper around :func:`load_datasets` for sample archives.
+
+    The sample data distributed with this project lives in zip archives.  This
+    helper simply delegates to :func:`load_datasets` but documents the intent
+    more clearly and provides a single import point for users analysing the
+    supplied sample data.
+
+    Parameters
+    ----------
+    zip_path:
+        Path to the sample dataset zip archive.
+
+    Returns
+    -------
+    Mapping[str, pandas.DataFrame]
+        DataFrames for every CSV file contained within ``zip_path``.
+    """
+
+    return load_datasets(zip_path)

--- a/inventory/demand_forecasting.py
+++ b/inventory/demand_forecasting.py
@@ -9,6 +9,10 @@ from __future__ import annotations
 import pandas as pd
 from statsmodels.tsa.holtwinters import ExponentialSmoothing
 
+from pathlib import Path
+
+from .datasets import load_datasets
+
 
 def forecast_demand(
     series: pd.Series,
@@ -46,3 +50,56 @@ def forecast_demand(
     ).fit()
     forecast = model.forecast(periods)
     return forecast
+
+
+def forecast_from_zip(
+    zip_path: str | Path,
+    sales_file: str,
+    date_col: str,
+    quantity_col: str,
+    periods: int,
+    *,
+    seasonal_periods: int | None = None,
+) -> pd.Series:
+    """Load sales data from a zip archive and forecast future demand.
+
+    The CSV file is read using :func:`load_datasets`.  The resulting DataFrame
+    is aggregated by ``date_col`` and the specified ``quantity_col`` is used as
+    the demand series.
+
+    Parameters
+    ----------
+    zip_path:
+        Path to the zip archive containing the sales data.
+    sales_file:
+        Name of the CSV file within the archive.
+    date_col, quantity_col:
+        Columns representing the sale date and quantity sold.
+    periods:
+        Number of future periods to forecast.
+    seasonal_periods:
+        Length of the seasonal cycle.  If ``None`` no seasonality is modelled.
+
+    Returns
+    -------
+    pandas.Series
+        Forecasted demand for the next ``periods`` periods.
+    """
+
+    datasets = load_datasets(zip_path, files=[sales_file])
+    key = Path(sales_file).stem
+    if key not in datasets:
+        raise FileNotFoundError(f"{sales_file!r} not found in {zip_path!r}")
+    df = datasets[key]
+    for col in (date_col, quantity_col):
+        if col not in df.columns:
+            raise KeyError(f"{col!r} not in sales data")
+
+    df[date_col] = pd.to_datetime(df[date_col])
+    series = df.groupby(df[date_col])[quantity_col].sum().sort_index()
+    series = series.asfreq("D", fill_value=0)
+    return forecast_demand(
+        series,
+        periods,
+        seasonal_periods=seasonal_periods,
+    )

--- a/inventory/eoq.py
+++ b/inventory/eoq.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 
 import math
 
+from pathlib import Path
+import pandas as pd
+
+from .datasets import load_datasets
+
 
 def calculate_eoq(demand: float, order_cost: float, holding_cost: float) -> float:
     """Compute the optimal order quantity using the EOQ formula.
@@ -29,3 +34,54 @@ def calculate_eoq(demand: float, order_cost: float, holding_cost: float) -> floa
         raise ValueError("holding_cost must be positive")
 
     return math.sqrt(2 * demand * order_cost / holding_cost)
+
+
+def calculate_eoq_from_df(
+    df: pd.DataFrame,
+    demand_col: str,
+    order_cost_col: str,
+    holding_cost_col: str,
+) -> pd.Series:
+    """Vectorised EOQ calculation for data frames.
+
+    Parameters
+    ----------
+    df:
+        Data containing demand, order cost and holding cost columns.
+    demand_col, order_cost_col, holding_cost_col:
+        Column names corresponding to the EOQ parameters.
+
+    Returns
+    -------
+    pandas.Series
+        EOQ for each row of ``df``.
+    """
+
+    for col in (demand_col, order_cost_col, holding_cost_col):
+        if col not in df.columns:
+            raise KeyError(f"{col!r} not in DataFrame")
+    return df.apply(
+        lambda r: calculate_eoq(r[demand_col], r[order_cost_col], r[holding_cost_col]),
+        axis=1,
+    )
+
+
+def calculate_eoq_from_zip(
+    zip_path: str | Path,
+    file_name: str,
+    demand_col: str,
+    order_cost_col: str,
+    holding_cost_col: str,
+) -> pd.Series:
+    """Load EOQ parameters from ``zip_path`` and compute EOQ values."""
+
+    datasets = load_datasets(zip_path, files=[file_name])
+    key = Path(file_name).stem
+    if key not in datasets:
+        raise FileNotFoundError(f"{file_name!r} not found in {zip_path!r}")
+    return calculate_eoq_from_df(
+        datasets[key],
+        demand_col,
+        order_cost_col,
+        holding_cost_col,
+    )

--- a/inventory/lead_time.py
+++ b/inventory/lead_time.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 
 import pandas as pd
 
+from pathlib import Path
+
+from .datasets import load_datasets
+
 
 def compute_lead_times(
     df: pd.DataFrame,
@@ -42,3 +46,25 @@ def compute_lead_times(
         return lead_times.groupby(df[group_col]).mean()
 
     return lead_times
+
+
+def compute_lead_times_from_zip(
+    zip_path: str | Path,
+    purchases_file: str,
+    order_date_col: str,
+    receipt_date_col: str,
+    *,
+    group_col: str | None = None,
+) -> pd.Series:
+    """Load purchase data from ``zip_path`` and compute lead times."""
+
+    datasets = load_datasets(zip_path, files=[purchases_file])
+    key = Path(purchases_file).stem
+    if key not in datasets:
+        raise FileNotFoundError(f"{purchases_file!r} not found in {zip_path!r}")
+    return compute_lead_times(
+        datasets[key],
+        order_date_col,
+        receipt_date_col,
+        group_col=group_col,
+    )

--- a/inventory/sales_analysis.py
+++ b/inventory/sales_analysis.py
@@ -70,6 +70,27 @@ def top_selling_from_zip(
     return top_selling_products(
         datasets[key],
         product_col,
-        quantity_col,
+       quantity_col,
+       top_n=top_n,
+    )
+
+
+def top_selling_sample(
+    zip_path: str | Path = "Sample.zip",
+    *,
+    top_n: int = 10,
+) -> pd.DataFrame:
+    """Convenience helper for the bundled sample sales dataset.
+
+    Assumes the sample archive contains ``SalesFINAL12312016_sample.csv`` with
+    product descriptions in the ``Description`` column and quantities in
+    ``SalesQuantity``.
+    """
+
+    return top_selling_from_zip(
+        zip_path,
+        sales_file="SalesFINAL12312016_sample.csv",
+        product_col="Description",
+        quantity_col="SalesQuantity",
         top_n=top_n,
     )

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from inventory import load_datasets, classify_inventory
+from inventory import load_datasets, load_sample_datasets, classify_inventory
 
 
 def _make_zip(path, files):
@@ -35,3 +35,11 @@ def test_classify_with_loaded_data(tmp_path):
     classified = classify_inventory(datasets["inventory"], "value")
     categories = classified.set_index("item")["category"].to_dict()
     assert categories == {"A": "A", "B": "B", "C": "C"}
+
+
+def test_load_sample_datasets(tmp_path):
+    df = pd.DataFrame({"a": [1]})
+    zip_path = _make_zip(tmp_path / "sample.zip", {"first": df})
+
+    loaded = load_sample_datasets(zip_path)
+    assert loaded["first"].equals(df)

--- a/tests/test_inventory.py
+++ b/tests/test_inventory.py
@@ -1,16 +1,33 @@
-import os, sys
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import os
+import sys
+import zipfile
 
 import pandas as pd
 import pytest
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from inventory import (
     calculate_eoq,
+    calculate_eoq_from_df,
+    calculate_eoq_from_zip,
     calculate_reorder_point,
+    calculate_reorder_points_from_df,
+    calculate_reorder_points_from_zip,
     classify_inventory,
+    classify_inventory_from_zip,
     compute_lead_times,
+    compute_lead_times_from_zip,
     forecast_demand,
+    forecast_from_zip,
 )
+
+
+def _make_zip(path, files):
+    with zipfile.ZipFile(path, "w") as zf:
+        for name, df in files.items():
+            zf.writestr(f"{name}.csv", df.to_csv(index=False))
+    return path
 
 
 def test_forecast_demand_returns_correct_length():
@@ -20,6 +37,13 @@ def test_forecast_demand_returns_correct_length():
     assert len(forecast) == 3
 
 
+def test_forecast_from_zip(tmp_path):
+    df = pd.DataFrame({"date": pd.date_range("2023-01-01", periods=3, freq="D"), "qty": [1, 2, 3]})
+    zip_path = _make_zip(tmp_path / "sales.zip", {"sales": df})
+    forecast = forecast_from_zip(zip_path, "sales.csv", "date", "qty", periods=2)
+    assert len(forecast) == 2
+
+
 def test_abc_classification():
     df = pd.DataFrame({"item": list("ABCD"), "value": [100, 60, 30, 10]})
     result = classify_inventory(df, "value")
@@ -27,14 +51,42 @@ def test_abc_classification():
     assert categories == {"A": "A", "B": "A", "C": "B", "D": "C"}
 
 
+def test_classify_inventory_from_zip(tmp_path):
+    inv_df = pd.DataFrame({"item": list("ABC"), "value": [100, 50, 10]})
+    zip_path = _make_zip(tmp_path / "inv.zip", {"inventory": inv_df})
+    classified = classify_inventory_from_zip(zip_path, "inventory.csv", "value")
+    categories = classified.set_index("item")["category"].to_dict()
+    assert categories == {"A": "A", "B": "B", "C": "C"}
+
+
 def test_eoq_formula():
     eoq = calculate_eoq(demand=1000, order_cost=50, holding_cost=5)
     assert pytest.approx(eoq, rel=1e-3) == 141.4213562373095
 
 
+def test_eoq_from_df_and_zip(tmp_path):
+    df = pd.DataFrame({"d": [1000], "o": [50], "h": [5]})
+    res = calculate_eoq_from_df(df, "d", "o", "h")
+    assert pytest.approx(res.iloc[0], rel=1e-3) == 141.4213562373095
+    zip_path = _make_zip(tmp_path / "eoq.zip", {"params": df})
+    from_zip = calculate_eoq_from_zip(zip_path, "params.csv", "d", "o", "h")
+    assert pytest.approx(from_zip.iloc[0], rel=1e-3) == 141.4213562373095
+
+
 def test_reorder_point():
     rop = calculate_reorder_point(10, 5, safety_stock=20)
     assert rop == 70
+
+
+def test_reorder_points_from_df_and_zip(tmp_path):
+    df = pd.DataFrame({"d": [10], "l": [5], "s": [20]})
+    res = calculate_reorder_points_from_df(df, "d", "l", safety_stock_col="s")
+    assert res.iloc[0] == 70
+    zip_path = _make_zip(tmp_path / "rop.zip", {"params": df})
+    from_zip = calculate_reorder_points_from_zip(
+        zip_path, "params.csv", "d", "l", safety_stock_col="s"
+    )
+    assert from_zip.iloc[0] == 70
 
 
 def test_lead_time():
@@ -49,3 +101,11 @@ def test_lead_time():
     assert list(res) == [10, 5]
     grouped = compute_lead_times(df, "order", "receive", group_col="supplier")
     assert pytest.approx(grouped["X"], rel=1e-3) == 7.5
+
+
+def test_lead_times_from_zip(tmp_path):
+    df = pd.DataFrame({"order": ["2024-01-01"], "receive": ["2024-01-11"]})
+    zip_path = _make_zip(tmp_path / "lead.zip", {"purchases": df})
+    res = compute_lead_times_from_zip(zip_path, "purchases.csv", "order", "receive")
+    assert list(res) == [10]
+

--- a/tests/test_sales_analysis.py
+++ b/tests/test_sales_analysis.py
@@ -1,4 +1,5 @@
 import os
+import os
 import sys
 import zipfile
 
@@ -6,7 +7,7 @@ import pandas as pd
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from inventory import top_selling_products, top_selling_from_zip
+from inventory import top_selling_products, top_selling_from_zip, top_selling_sample
 
 
 def _make_zip(path, files):
@@ -34,4 +35,12 @@ def test_top_selling_from_zip(tmp_path):
         top_n=1,
     )
     assert result.iloc[0]["product"] == "A"
+    assert result.iloc[0]["total_quantity"] == 13
+
+
+def test_top_selling_sample(tmp_path):
+    df = pd.DataFrame({"Description": ["A", "B", "A"], "SalesQuantity": [10, 5, 3]})
+    zip_path = _make_zip(tmp_path / "Sample.zip", {"SalesFINAL12312016_sample": df})
+    result = top_selling_sample(zip_path=zip_path, top_n=1)
+    assert result.iloc[0]["Description"] == "A"
     assert result.iloc[0]["total_quantity"] == 13


### PR DESCRIPTION
## Summary
- add load_sample_datasets and wrapper functions to operate directly on zipped CSV archives
- expose new `*_from_zip` helpers for ABC analysis, demand forecasting, EOQ, reorder points and lead time calculations
- provide `top_selling_sample` and document using the bundled Sample.zip dataset

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7d0f01d8832ab831bd43ee0d9c0a